### PR TITLE
Colorization in and operational

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -317,6 +317,12 @@ var ttp = {
 		if (popups.length > 0) {
             popups[0].addMessage(message);
         }
+       	ttp.send({
+                highlightUserName: {
+                    name: window.escape(message.name),
+                    text: window.escape(message.text)
+                }
+            });
 		if (this.user.userid !== message.userid && this.chatNotification_re.test(message.text)) {
 			if (popups.length > 0) {
                 popups[0].buildChatlog();

--- a/scripts/listener.js
+++ b/scripts/listener.js
@@ -49,6 +49,8 @@ var ttplus = {
                         success: response
                     }
                 });
+            } else if (typeof request.highlightUserName === "object") {
+                ttplus.injectScript(ttplus.highlightChatUserName, request.highlightUserName);
             } else if (typeof request.highlightMessage === "object") {
                 ttplus.injectScript(ttplus.highlightChatMessage, request.highlightMessage);
             } else if (typeof request.speak === "string") {
@@ -717,7 +719,44 @@ var ttplus = {
 			}
 		});
 	},
-    toggleMute: function () {
+	highlightUserName: function (message) {
+		$($(".message").get().reverse()).each(function () {
+			if ($(this).find(".speaker").text() === unescape(message.name) && $(this).find(".text").text() === (": " + unescape(message.text))) {
+
+				var colors = [
+							"indianred", "lightcoral", "salmon", "darksalmon", "lightsalmon", "red", 
+							"crimson", "fireBrick", "darkred", "hotpink", "deeppink", "mediumvioletred", 
+							"palevioletred", "lightsalmon", "coral", "tomato", "orangered", "darkorange", 
+							"orange", "darkkhaki", "thistle", "plum", "violet", "orchid", "fuchsia", 
+							"Magenta", "mediumorchid", "mediumpurple", "darkviolet", "darkorchid", 
+							"darkmagenta", "purple", "indigo", "darkslateblue", "slateblue", 
+							"mediumslateblue", "reenyellow", "chartreuse", "lawngreen", "lime", 
+							"limegreen", "palegreen", "lightgreen", "mediumspringgreen", "springgreen", 
+							"mediumseagreen", "seagreen", "forestgreen", "green", "darkgreen", 
+							"yellowgreen", "olivedrab", "olive", "darkolivegreen", "mediumaquamarine", 
+							"darkseagreen", "lightseagreen", "darkcyan", "teal", "paleturquoise",
+							"aquamarine", "turquoise", "mediumturquoise", "darkturquoise", "cadetblue",
+							"steelblue", "lightsteelblue", "powderblue", "lightblue", "skyblue", 
+							"lightskyblue", "deepskyblue", "dodgerblue", "cornflowerblue", "royalblue", 
+							"blue", "mediumblue", "darkblue", "navy", "midnightblue", "burlywood", "tan",
+							"rosybrown", "sandybrown", "goldenrod", "darkgoldenrod", "Peru", "chocolate",
+							"saddlebrown", "sienna", "brown", "maroon", "silver", "darkgray", "gray", 
+							"dimgray", "lightslategray", "slategray", "darkslategray"
+						];
+
+				var i, hash = 0;
+				for (i = 0; i < message.name.length; i++) {
+					hash += (message.name[i].charCodeAt() * (i+1));
+				}
+
+				var index = Math.abs(hash % colors.length);
+
+				$(this).find(".speaker").css("color",  colors[index]);
+				return;
+			}
+		});
+	},
+	toggleMute: function () {
         var volume = ttp.roommanager.volume_bars ? 0 : ttp.roommanager.last_volume_bars;
 		ttp.roommanager.set_volume(volume);
 		ttp.roommanager.callback("set_volume", ttp.roommanager.volume_bars);

--- a/scripts/listener.js
+++ b/scripts/listener.js
@@ -719,7 +719,7 @@ var ttplus = {
 			}
 		});
 	},
-	highlightUserName: function (message) {
+	highlightChatUserName: function (message) {
 		$($(".message").get().reverse()).each(function () {
 			if ($(this).find(".speaker").text() === unescape(message.name) && $(this).find(".text").text() === (": " + unescape(message.text))) {
 


### PR DESCRIPTION
As promised, I've got basic username colorization working. This feature is enabled by default and cannot be disabled. In addition, usernames are not colorized in notification messages (e.g XXX started playing "YYY" by ZZZ).

If you'd like more features before finalizing a pull request, I'm game.
